### PR TITLE
Fix description of session on multiple remotes

### DIFF
--- a/user-guide.md
+++ b/user-guide.md
@@ -153,7 +153,7 @@ If more than one remote hosts are given, the plugin will connect to all remote h
 For instance,
 
 ```groovy
-session(remotes.web01, remotes.web02) {
+session([remotes.web01, remotes.web02]) {
   //execute ...
 }
 ```

--- a/user-guide.v3.md
+++ b/user-guide.v3.md
@@ -157,7 +157,7 @@ If more than one remote hosts are given, the plugin will connect to all remote h
 For instance,
 
 ```groovy
-session(remotes.web01, remotes.web02) {
+session([remotes.web01, remotes.web02]) {
   //execute ...
 }
 ```


### PR DESCRIPTION
See #4. Fix the document for now but behavior of `session` will be fixed in the future release.
